### PR TITLE
Tests para run_openssl_s_client y check_tls_version

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+# pytest.ini
+[pytest]
+pythonpath = src

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+click>=8.0
+coverage>=7.0
+pytest>=7.0

--- a/tests/unit/test_auditors.py
+++ b/tests/unit/test_auditors.py
@@ -1,0 +1,40 @@
+import pytest
+from audit_cli import auditors
+
+MOCK_SUCCESS_OUTPUT = """
+Protocol  : TLSv1.2
+Cipher    : ECDHE-RSA-AES256-GCM-SHA384
+"""
+
+MOCK_REFUSED_OUTPUT = "connect:errno=111 Connection refused"
+MOCK_TIMEOUT_EXCEPTION = TimeoutError("Comando openssl timed out")
+
+
+@pytest.mark.parametrize(
+    "stub_simulation, expected_status, expected_details_fragment",
+    [
+        (MOCK_SUCCESS_OUTPUT, "OK", "TLSv1.2 detectado"),
+        (MOCK_REFUSED_OUTPUT, "ERROR", "Conexion rechazada"),
+        (MOCK_TIMEOUT_EXCEPTION, "ERROR", "timed out"),
+        ("some other random output", "FAIL", "no detectado"),
+    ]
+)
+def test_check_tls_parametrized(
+    monkeypatch,
+    stub_simulation,
+    expected_status,
+    expected_details_fragment
+):
+
+    def mock_run_openssl(host: str, port: int) -> str:
+        if isinstance(stub_simulation, Exception):
+            raise stub_simulation
+        return stub_simulation
+
+    monkeypatch.setattr(auditors.runners, "run_openssl_s_client", mock_run_openssl)
+
+    result = auditors.check_tls_version("fake-host.com", 443)
+
+    assert result["status"] == expected_status
+    assert expected_details_fragment in result["details"]
+    assert result["host"] == "fake-host.com"

--- a/tests/unit/test_auditors.py
+++ b/tests/unit/test_auditors.py
@@ -38,3 +38,18 @@ def test_check_tls_parametrized(
     assert result["status"] == expected_status
     assert expected_details_fragment in result["details"]
     assert result["host"] == "fake-host.com"
+
+
+def test_check_tls_handles_unknown_exception(monkeypatch):
+
+    def raise_value_error(host: str, port: int) -> str:
+        raise ValueError("error")
+
+    monkeypatch.setattr(auditors.runners, "run_openssl_s_client", raise_value_error)
+
+    result = auditors.check_tls_version("fake-host.com", 443)
+
+    assert result["status"] == "ERROR"
+    assert "Unknown error" in result["details"]
+    assert "error" in result["details"]
+

--- a/tests/unit/test_runners.py
+++ b/tests/unit/test_runners.py
@@ -1,0 +1,13 @@
+import subprocess
+import pytest
+from audit_cli import runners
+
+def test_run_openssl_success(monkeypatch):
+    def fake_run(args, capture_output, text, timeout, check):
+        # comprueba que el comando se construye correctamente
+        assert any("-tls1_2" in token or "tls1_2" in token for token in args) 
+        # simula una ejecucion exitosa
+        return subprocess.CompletedProcess(args, 0, stdout="REAL STDOUT", stderr="")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    out = runners.run_openssl_s_client("host.test", 443)
+    assert out == "REAL STDOUT"

--- a/tests/unit/test_runners.py
+++ b/tests/unit/test_runners.py
@@ -11,3 +11,10 @@ def test_run_openssl_success(monkeypatch):
     monkeypatch.setattr(subprocess, "run", fake_run)
     out = runners.run_openssl_s_client("host.test", 443)
     assert out == "REAL STDOUT"
+
+def test_run_openssl_calledprocesserror_returns_stderr(monkeypatch):
+    def fake_run(args, capture_output, text, timeout, check):
+        raise subprocess.CalledProcessError(returncode=1, cmd=args, stderr="ERR-STERR")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    out = runners.run_openssl_s_client("host.test", 443)
+    assert out == "ERR-STERR"


### PR DESCRIPTION
Este PR agrega tests unitarios para las funciones `run_openssl_s_client` y `check_tls_version`, asegurando que distintos escenarios de ejecucion y errores se manejen correctamente.

Se logra:

- [x] Test para `run_openssl_s_client` verificando comandos correctos, retorno de `stdout` y manejo de errores (`CalledProcessError`).
- [x] Tests parametrizados para `check_tls_version` cubriendo: exito TLSv1.2, conexion rechazada, timeout y salida inesperada.
- [x] Test para excepciones desconocidas, asegurando que se marquen como `ERROR`.
- [x] Uso de `monkeypatch` para simular ejecuciones sin depender de OpenSSL real.

cumple con lo requerido en la issue #5 

